### PR TITLE
Fix wrong ts-ignore and add section on next/image config to the documentation

### DIFF
--- a/packages/next-tweet/readme.md
+++ b/packages/next-tweet/readme.md
@@ -28,10 +28,8 @@ const nextConfig = {
   images: {
     // If you want to use images.remotePatterns:
     remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'pbs.twimg.com',
-      },
+      { protocol: 'https', hostname: 'pbs.twimg.com' },
+      { protocol: 'https', hostname: 'abs.twimg.com' },
     ],
     // or if you want to use images.domains:
     // domains: ['pbs.twimg.com', 'abs.twimg.com'],

--- a/packages/next-tweet/readme.md
+++ b/packages/next-tweet/readme.md
@@ -20,6 +20,26 @@ yarn add next-tweet
 npm install next-tweet
 ```
 
+Since `next-tweet` uses `next/image` behind the scenes, you also need to configure `next/image` to accept image URLs from Twitter, by using [`images.remotePatterns`](https://nextjs.org/docs/api-reference/next/image#remote-patterns) or [`images.domains`](https://nextjs.org/docs/api-reference/next/image#remote-patterns) in your `next.config.js`:
+
+```js
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    // If you want to use images.remotePatterns:
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'pbs.twimg.com',
+      },
+    ],
+    // or if you want to use images.domains:
+    // domains: ['pbs.twimg.com', 'abs.twimg.com'],
+  },
+  // ... other Next.js config options
+}
+```
+
 ## How to use in the app directory
 
 In any component, import `NextTweet` from `next-tweet` and use it like so:
@@ -28,9 +48,9 @@ In any component, import `NextTweet` from `next-tweet` and use it like so:
 import { NextTweet } from 'next-tweet'
 
 export default async function Page({ params }: Props) {
-  // @ts-ignore: Async components are valid in the app directory
   return (
     <div data-theme="light">
+      {/* @ts-ignore: Async components are valid in the app directory */}
       <NextTweet id={params.tweet} priority />
     </div>
   )


### PR DESCRIPTION
* Previously the `ts-ignore` comment was in the wrong place, I corrected it.

* Since we need to allow Twitter domains for the package to work, I added a section on this issue to the documentation.